### PR TITLE
Fix 0x9 and white spaces at EOL

### DIFF
--- a/Tools/Get-AllC++Runtimes/Get-Downloads.ps1
+++ b/Tools/Get-AllC++Runtimes/Get-Downloads.ps1
@@ -1,16 +1,16 @@
 <#
  ##################################################################################
- #  Script name: DownloadAll.ps1
- #  Created:		2012-12-26
- #  version:		v1.0
+ #  Script name: DownloadAllVC++.ps1
+ #  Created:     2012-12-26
+ #  version:     v1.0
  #  Author:      Mikael Nystrom
- #  Homepage:    http://deploymentbunny.com/
+ #  Homepage:    https://deploymentbunny.com/2014/08/05/powershell-is-king-download-all-vc-runtimes-using-a-script/
  ##################################################################################
- 
+
  ##################################################################################
  #  Disclaimer:
  #  -----------
- #  This script is provided "AS IS" with no warranties, confers no rights and 
+ #  This script is provided "AS IS" with no warranties, confers no rights and
  #  is not supported by the authors or DeploymentBunny.
  ##################################################################################
 #>
@@ -108,7 +108,7 @@ foreach($DataRecord in $Data.Download.DownloadItem){
             else
         {
             Logit "$FullName needs to be fixed."
-            #Selecting correct method to extract data 
+            #Selecting correct method to extract data
             Switch($CommandType){
                 EXEType01{
                     $Command = $DestinationFolder + "\" + $Command

--- a/Tools/Get-AllC++Runtimes/download.xml
+++ b/Tools/Get-AllC++Runtimes/download.xml
@@ -1,30 +1,5 @@
-﻿<Download>
+<Download>
     <DownloadItem>
-        <Comment></Comment>
-        <FullName>Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)</FullName>
-        <ShortName>VS2005X86SP1</ShortName>
-        <Source>http://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x86.EXE</Source>
-        <DestinationFolder>VS2005</DestinationFolder>
-        <DestinationFile>vcredist_x86.exe</DestinationFile>
-        <URL>http://www.microsoft.com</URL>
-        <CommandType>NONE</CommandType>
-        <Command></Command>
-        <CommandLineSwitches></CommandLineSwitches>
-        <VerifyAfterCommand></VerifyAfterCommand>
-    </DownloadItem>
-    <DownloadItem>
-        <Comment></Comment>
-        <FullName>Microsoft Visual C++ 2005 SP1 Redistributable Package (x64)</FullName>
-        <ShortName>VS2005X64SP1</ShortName>
-        <Source>http://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE</Source>
-        <DestinationFolder>VS2005</DestinationFolder>
-        <DestinationFile>vcredist_x64.exe</DestinationFile>
-        <URL>http://www.microsoft.com</URL>
-        <CommandType>NONE</CommandType>
-        <Command></Command>
-        <CommandLineSwitches></CommandLineSwitches>
-        <VerifyAfterCommand></VerifyAfterCommand>
-    </DownloadItem>
     <DownloadItem>
         <Comment></Comment>
         <FullName>Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)</FullName>
@@ -131,33 +106,7 @@
     </DownloadItem>
     <DownloadItem>
         <Comment></Comment>
-        <FullName>Visual C++ Redistributable for Visual Studio 2015 (x86)</FullName>
-        <ShortName>VS2015X86</ShortName>
-        <Source>https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe</Source>
-        <DestinationFolder>VS2015</DestinationFolder>
-        <DestinationFile>vc_redist.x86.exe</DestinationFile>
-        <URL>http://www.microsoft.com</URL>
-        <CommandType>NONE</CommandType>
-        <Command></Command>
-        <CommandLineSwitches></CommandLineSwitches>
-        <VerifyAfterCommand></VerifyAfterCommand>
-    </DownloadItem>
-    <DownloadItem>
-        <Comment></Comment>
-        <FullName>Visual C++ Redistributable for Visual Studio 2015 (x64)</FullName>
-        <ShortName>VS2015X64</ShortName>
-        <Source>https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe</Source>
-        <DestinationFolder>VS2015</DestinationFolder>
-        <DestinationFile>vc_redist.x64.exe</DestinationFile>
-        <URL>http://www.microsoft.com</URL>
-        <CommandType>NONE</CommandType>
-        <Command></Command>
-        <CommandLineSwitches></CommandLineSwitches>
-        <VerifyAfterCommand></VerifyAfterCommand>
-    </DownloadItem>
-    <DownloadItem>
-        <Comment></Comment>
-        <FullName>Visual C++ Redistributable for Visual Studio 2015 (x86)</FullName>
+        <FullName>Visual C++ Redistributable for Visual Studio 2017 (x86)</FullName>
         <ShortName>VS2017X86</ShortName>
         <Source>https://go.microsoft.com/fwlink/?LinkId=746571</Source>
         <DestinationFolder>VS2017</DestinationFolder>


### PR DESCRIPTION
Hi, Mikael!
I made some minor changes to the code formatting of the Get-AllC++Runtimes\Get-Downloads.ps1 script and change the link to the Home Page