### PR TITLE
Update download.xml

### DIFF
--- a/Tools/Get-AllC++Runtimes/download.xml
+++ b/Tools/Get-AllC++Runtimes/download.xml
@@ -1,6 +1,5 @@
 <Download>
     <DownloadItem>
-    <DownloadItem>
         <Comment></Comment>
         <FullName>Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)</FullName>
         <ShortName>VS2008X86SP1</ShortName>


### PR DESCRIPTION
Removed an extra "`<DownloadItem>`" from Line 2; this was causing the script to be unable to parse Download.xml when ran.

[09/17/2018 12:13:41] [Reading datafile - Reading from .\download.xml]
Cannot convert value "System.Object[]" to type "System.Xml.XmlDocument". Error: "The 'DownloadItem' start tag on line 2 position 6 does not match the end tag of 
'Download'. Line 133, position 3."
At C:\Users\username\Desktop\Get-VCDownloads.ps1:43 char:1
+ [xml]$Data = Get-Content $DownloadFile
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : MetadataError: (:) [], ArgumentTransformationMetadataException
    + FullyQualifiedErrorId : RuntimeException